### PR TITLE
feat: Add spending by date range and income tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Balance Check: Ask "What's my balance?" to see the current balance.
 Transaction History: Query "Show transactions" to view the last 5 transactions.
 Spending Insights: Ask "How much did I spend on food?" or "Total spent" for category or overall spending.
 Largest Expense: Query "What's my biggest expense?" to find the highest transaction.
+Spending by Date Range: Analyze expenses within specific periods, like "last week" or "in April".
+Income Tracking: Monitor income from various sources, view total income, or income for specific periods like "last month".
 Data Persistence: Account data is saved to account.json for continuity.
 Web Interface: A clean, browser-based chat UI powered by Streamlit.
 
@@ -50,7 +52,13 @@ Example Queries:
 "What's my balance?" → "Your balance is $500.00."
 "How much did I spend on food?" → "You spent $100.00 on food."
 "What's my biggest expense?" → "Your largest expense was $50.00 at Coffee Shop on 2025-05-01."
-"Show transactions" → Lists recent transactions with dates, amounts, and categories
+"Show transactions" → Lists recent transactions with dates, amounts (+/-), and categories.
+"How much did I spend last week?" → Shows total spending for the previous week.
+"What were my expenses in April?" → Displays total spending for April of the current year.
+"What was my income last month?" → Shows total income received in the previous calendar month.
+"How much income did I receive in total?" → Displays your aggregate income.
+"Show my income transactions." → Lists all transactions where you received money.
+"How much income from salary?" → Shows total income specifically from the "salary" category.
 
 
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import json
 import os
+from datetime import datetime, timedelta, date
 
 # Mock bank account data (loaded from/saved to JSON)
 ACCOUNT_FILE = "account.json"
@@ -39,6 +40,18 @@ def get_spending_by_category(category):
     return total
 
 
+# Get total income
+def get_total_income(transactions):
+    total = sum(t["amount"] for t in transactions if t["amount"] > 0)
+    return total
+
+
+# Get income by category
+def get_income_by_category(category_name):
+    total = sum(t["amount"] for t in account["transactions"] if t["category"].lower() == category_name.lower() and t["amount"] > 0)
+    return total
+
+
 # Get largest transaction
 def get_largest_transaction():
     expenses = [t for t in account["transactions"] if t["amount"] < 0]
@@ -46,6 +59,35 @@ def get_largest_transaction():
         return None
     largest = max(expenses, key=lambda x: abs(x["amount"]))
     return largest
+
+
+# Get spending by date range
+def get_spending_by_date_range(transactions, start_date_obj, end_date_obj):
+    total_spent = 0
+    for t in transactions:
+        try:
+            transaction_date_obj = datetime.strptime(t["date"], "%Y-%m-%d").date()
+            if t["amount"] < 0 and start_date_obj <= transaction_date_obj <= end_date_obj:
+                total_spent += abs(t["amount"])
+        except ValueError:
+            # Handle cases where date parsing might fail for a transaction, though unlikely with current data
+            print(f"Warning: Could not parse date for transaction: {t}")
+            continue
+    return total_spent
+
+
+# Get income by date range
+def get_income_by_date_range(transactions, start_date_obj, end_date_obj):
+    total_income = 0
+    for t in transactions:
+        try:
+            transaction_date_obj = datetime.strptime(t["date"], "%Y-%m-%d").date()
+            if t["amount"] > 0 and start_date_obj <= transaction_date_obj <= end_date_obj:
+                total_income += t["amount"]
+        except ValueError:
+            print(f"Warning: Could not parse date for transaction: {t}") # Should not happen with current data
+            continue
+    return total_income
 
 
 # Process user query (rule-based)
@@ -56,32 +98,115 @@ def process_query(query):
     if "balance" in query:
         return f"Your balance is ${account['balance']:.2f}."
 
-    # List recent transactions
+    # List transactions (general, or filtered for income)
+    # Handles "transaction history", "show my transactions", "show income transactions"
     elif "transaction" in query or "history" in query:
-        response = "Recent transactions:\n"
-        for t in account["transactions"][-5:]:
-            response += f"{t['date']}: {t['description']} (${t['amount']:.2f}, {t['category']})\n"
+        if "income" in query : # e.g. "show income transactions"
+            response = "Income transactions:\n"
+            income_transactions = [t for t in account["transactions"] if t["amount"] > 0]
+            if not income_transactions:
+                return "No income transactions found."
+            # Sort by date, most recent first, then format
+            for t in sorted(income_transactions, key=lambda x: x['date'], reverse=True):
+                response += f"{t['date']}: {t['description']} (${t['amount']:+.2f}, {t['category']})\n"
+        else: # General transaction history
+            response = "Recent transactions:\n"
+            # Display last 5 transactions or fewer if not enough, most recent first
+            # Sorting by date before taking last 5 might be better if data isn't pre-sorted. Assuming it is for now.
+            display_transactions = sorted(account["transactions"], key=lambda x: x['date'], reverse=True)[-5:]
+            if not display_transactions:
+                return "No transactions found."
+            for t in display_transactions:
+                response += f"{t['date']}: {t['description']} (${t['amount']:+.2f}, {t['category']})\n"
         return response.strip()
 
-    # Total spending
-    elif "spent" in query and not any(c in query for c in ["food", "transport"]):
-        total_spent = sum(abs(t["amount"]) for t in account["transactions"] if t["amount"] < 0)
-        return f"You've spent ${total_spent:.2f} in total."
 
-    # Spending by category
-    elif "food" in query:
+    # Total spending (more specific to avoid clashes)
+    elif "spent" in query and "total" in query: # e.g. "how much have I spent in total?"
+        total_spent_val = sum(abs(t["amount"]) for t in account["transactions"] if t["amount"] < 0)
+        return f"You've spent ${total_spent_val:.2f} in total."
+
+    # Total income
+    elif "income" in query and "total" in query : # e.g. "how much income in total?"
+        total_income_val = get_total_income(account["transactions"])
+        return f"Your total income is ${total_income_val:.2f}."
+
+    # Spending by category (more specific)
+    elif "spend on food" in query or ("food" in query and "spent" in query): # order matters for parsing "food"
         total = get_spending_by_category("food")
         return f"You spent ${total:.2f} on food."
-    elif "transport" in query:
+    elif "spend on transport" in query or ("transport" in query and "spent" in query):
         total = get_spending_by_category("transport")
         return f"You spent ${total:.2f} on transport."
+    # Add other spending categories as needed
 
-    # Largest transaction
-    elif "largest" in query or "biggest" in query:
+    # Income by category (e.g., "income from salary")
+    elif "income from" in query:
+        category_name = query.split("income from")[-1].strip().rstrip('?.!') # Remove punctuation
+        if category_name:
+            total_income_cat = get_income_by_category(category_name)
+            if total_income_cat > 0:
+                 return f"You received ${total_income_cat:.2f} as income from {category_name}."
+            else:
+                 return f"No income found from {category_name} or '{category_name}' is not an income category."
+        else: # "income from " with nothing after
+            return "Please specify a category for income (e.g., 'income from salary')."
+
+
+    # Income last month
+    elif "income last month" in query or ("last month" in query and "income" in query):
+        today = date.today()
+        first_day_current_month = today.replace(day=1)
+        end_of_last_month = first_day_current_month - timedelta(days=1)
+        start_of_last_month = end_of_last_month.replace(day=1)
+        total_income_last_month = get_income_by_date_range(account["transactions"], start_of_last_month, end_of_last_month)
+        return f"Your income last month ({start_of_last_month.strftime('%B %Y')}) was ${total_income_last_month:.2f} (from {start_of_last_month.strftime('%Y-%m-%d')} to {end_of_last_month.strftime('%Y-%m-%d')})."
+
+    # Largest transaction (implies expense)
+    elif "largest" in query or "biggest" in query: # This implies expense
         largest = get_largest_transaction()
         if largest:
             return f"Your largest expense was ${abs(largest['amount']):.2f} at {largest['description']} on {largest['date']}."
         return "No expenses found."
+
+    # Spending last week
+    elif "last week" in query and "spend" in query:
+        today = date.today()
+        start_of_last_week = today - timedelta(days=today.weekday() + 7)
+        end_of_last_week = today - timedelta(days=today.weekday() + 1)
+        total_spent = get_spending_by_date_range(account["transactions"], start_of_last_week, end_of_last_week)
+        return f"You spent ${total_spent:.2f} last week (from {start_of_last_week.strftime('%Y-%m-%d')} to {end_of_last_week.strftime('%Y-%m-%d')})."
+
+    # Spending in a specific month
+    elif "in " in query and ("spend" in query or "expenses" in query): # e.g. "how much did I spend in May?"
+        # Basic month extraction, assumes "in [Month]" format for spending
+        try:
+            # query.split("in ")[1] gets text after "in "
+            # .split(" ")[0] gets the first word (month)
+            month_name_str = query.split("in ")[1].split(" ")[0].strip().lower().rstrip('?.!')
+            month_map = {
+                "january": 1, "february": 2, "march": 3, "april": 4,
+                "may": 5, "june": 6, "july": 7, "august": 8,
+                "september": 9, "october": 10, "november": 11, "december": 12
+            }
+            month_number = month_map.get(month_name_str)
+
+            if month_number:
+                current_year = datetime.now().year
+                start_date_month = date(current_year, month_number, 1)
+                if month_number == 12:
+                    end_date_month = date(current_year, 12, 31)
+                else:
+                    end_date_month = date(current_year, month_number + 1, 1) - timedelta(days=1)
+
+                total_spent = get_spending_by_date_range(account["transactions"], start_date_month, end_date_month)
+                return f"You spent ${total_spent:.2f} in {month_name_str.capitalize()} {current_year} (from {start_date_month.strftime('%Y-%m-%d')} to {end_date_month.strftime('%Y-%m-%d')})."
+            else:
+                return "Could not determine the month from your query. Please use a full month name (e.g., 'in April')."
+        except IndexError:
+            # This might happen if "in " is at the end of the query
+            return "Sorry, I couldn't understand the date range. Try 'how much did I spend last week?' or 'what were my expenses in April?'"
+
 
     # Default response
     else:

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,228 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from datetime import date, datetime, timedelta
+
+# Assuming main.py is in the same directory or accessible in PYTHONPATH
+# If main.py is one level up, you might need path adjustments in a real scenario,
+# but for this environment, direct import should work if both are in /app
+import main
+
+# Define a fixed "today" for consistent testing of relative date queries
+FIXED_TODAY = date(2025, 5, 15)
+
+MOCK_TRANSACTIONS_BASE = [
+    # Expenses
+    {"date": "2025-05-01", "amount": -50.00, "description": "Coffee Shop", "category": "food"},
+    {"date": "2025-05-02", "amount": -20.00, "description": "Grocery Store", "category": "food"},
+    {"date": "2025-05-04", "amount": -30.00, "description": "Restaurant", "category": "food"},
+    {"date": "2025-05-05", "amount": -15.00, "description": "Bus Ticket", "category": "transport"},
+    {"date": "2025-04-20", "amount": -25.00, "description": "Books", "category": "education"},
+    {"date": "2025-04-28", "amount": -10.00, "description": "Snacks", "category": "food"},
+
+    # Income
+    {"date": "2025-05-03", "amount": 200.00, "description": "Salary Deposit", "category": "salary"},
+    {"date": "2025-04-15", "amount": 120.00, "description": "Freelance Payment", "category": "freelance"},
+    {"date": "2025-03-10", "amount": 190.00, "description": "Old Salary Deposit", "category": "salary"}, # Older income
+
+    # Mixed Category (hypothetical, if a category could have in/out)
+    {"date": "2025-05-10", "amount": 50.00, "description": "Project A Bonus", "category": "projectA"},
+    {"date": "2025-05-11", "amount": -10.00, "description": "Project A Software", "category": "projectA"},
+]
+
+class TestFinancialFunctions(unittest.TestCase):
+
+    def setUp(self):
+        # Make a deep copy of transactions for each test to avoid modification issues
+        self.mock_transactions = [t.copy() for t in MOCK_TRANSACTIONS_BASE]
+        # It's good practice to also patch main.account if functions directly use it.
+        # For functions that accept transactions as an argument, this is less critical for those specific functions.
+        self.patcher_account = patch('main.account', {'transactions': self.mock_transactions, 'balance': 1000.0})
+        self.mocked_account = self.patcher_account.start()
+        main.account['transactions'] = self.mock_transactions # Ensure it's updated for process_query
+
+    def tearDown(self):
+        self.patcher_account.stop()
+
+    # --- Tests for get_spending_by_date_range ---
+    def test_spending_range_includes_some(self):
+        start_date = date(2025, 5, 1)
+        end_date = date(2025, 5, 4)
+        # Expected: -50 (Coffee) + -20 (Grocery) + -30 (Restaurant) = -100. Function returns positive sum.
+        self.assertEqual(main.get_spending_by_date_range(self.mock_transactions, start_date, end_date), 100.00)
+
+    def test_spending_range_includes_none(self):
+        start_date = date(2025, 1, 1)
+        end_date = date(2025, 1, 31)
+        self.assertEqual(main.get_spending_by_date_range(self.mock_transactions, start_date, end_date), 0.00)
+
+    def test_spending_range_empty_transactions(self):
+        start_date = date(2025, 5, 1)
+        end_date = date(2025, 5, 4)
+        self.assertEqual(main.get_spending_by_date_range([], start_date, end_date), 0.00)
+
+    def test_spending_range_all_transactions(self):
+        start_date = date(2025, 1, 1)
+        end_date = date(2025, 12, 31)
+        # Expected: 50+20+30+15+25+10+10 = 160
+        self.assertEqual(main.get_spending_by_date_range(self.mock_transactions, start_date, end_date), 160.00)
+
+    # --- Tests for get_income_by_date_range ---
+    def test_income_range_includes_some(self):
+        start_date = date(2025, 4, 1)
+        end_date = date(2025, 4, 30)
+        # Expected: 120 (Freelance)
+        self.assertEqual(main.get_income_by_date_range(self.mock_transactions, start_date, end_date), 120.00)
+
+    def test_income_range_includes_none(self):
+        start_date = date(2024, 1, 1)
+        end_date = date(2024, 12, 31) # Range with no income transactions
+        self.assertEqual(main.get_income_by_date_range(self.mock_transactions, start_date, end_date), 0.00)
+
+    def test_income_range_empty_transactions(self):
+        start_date = date(2025, 5, 1)
+        end_date = date(2025, 5, 4)
+        self.assertEqual(main.get_income_by_date_range([], start_date, end_date), 0.00)
+
+    def test_income_range_all_transactions(self):
+        start_date = date(2025, 1, 1)
+        end_date = date(2025, 12, 31)
+        # Expected: 200 (Salary) + 120 (Freelance) + 190 (Old Salary) + 50 (Project A Bonus) = 560
+        self.assertEqual(main.get_income_by_date_range(self.mock_transactions, start_date, end_date), 560.00)
+
+
+    # --- Tests for get_total_income ---
+    def test_total_income_with_income(self):
+        # Expected: 200 + 120 + 190 + 50 = 560
+        self.assertEqual(main.get_total_income(self.mock_transactions), 560.00)
+
+    def test_total_income_no_income(self):
+        expenses_only = [t for t in self.mock_transactions if t['amount'] < 0]
+        self.assertEqual(main.get_total_income(expenses_only), 0.00)
+
+    def test_total_income_empty_transactions(self):
+        self.assertEqual(main.get_total_income([]), 0.00)
+
+    # --- Tests for get_income_by_category ---
+    def test_income_category_exists(self):
+        # Expected for "salary": 200 (Salary) + 190 (Old Salary) = 390
+        self.assertEqual(main.get_income_by_category("salary"), 390.00)
+        self.assertEqual(main.get_income_by_category("freelance"), 120.00)
+
+    def test_income_category_case_insensitivity(self):
+        self.assertEqual(main.get_income_by_category("SALary"), 390.00)
+        self.assertEqual(main.get_income_by_category("FrEeLanCe"), 120.00)
+
+
+    def test_income_category_not_exists(self):
+        self.assertEqual(main.get_income_by_category("nonexistent"), 0.00)
+
+    def test_income_category_mixed_types(self):
+        # Category "projectA" has +50 and -10. Should only sum income.
+        self.assertEqual(main.get_income_by_category("projectA"), 50.00)
+        # Category "food" only has expenses.
+        self.assertEqual(main.get_income_by_category("food"), 0.00)
+
+
+    def test_income_category_empty_transactions(self):
+        # Temporarily use empty list for this specific main.account.transactions
+        original_transactions = main.account['transactions']
+        main.account['transactions'] = []
+        self.assertEqual(main.get_income_by_category("salary"), 0.00)
+        main.account['transactions'] = original_transactions # Restore
+
+
+class TestProcessQuery(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_transactions = [t.copy() for t in MOCK_TRANSACTIONS_BASE]
+        # Patch main.account for process_query tests
+        self.patcher_account = patch('main.account', {'transactions': self.mock_transactions, 'balance': 1000.0})
+        self.mocked_account = self.patcher_account.start()
+        main.account['transactions'] = self.mock_transactions # Ensure it's updated
+
+        # Patch date/datetime objects for date-sensitive queries
+        self.patcher_date_today = patch('main.date')
+        self.mock_date = self.patcher_date_today.start()
+        self.mock_date.today.return_value = FIXED_TODAY
+
+        self.patcher_datetime_now = patch('main.datetime')
+        self.mock_datetime = self.patcher_datetime_now.start()
+        self.mock_datetime.now.return_value = MagicMock(year=FIXED_TODAY.year, month=FIXED_TODAY.month, day=FIXED_TODAY.day)
+        self.mock_datetime.strptime = datetime.strptime # Keep original strptime
+
+    def tearDown(self):
+        self.patcher_account.stop()
+        self.patcher_date_today.stop()
+        self.patcher_datetime_now.stop()
+
+    def test_query_spending_last_week(self):
+        # FIXED_TODAY is 2025-05-15 (Thursday)
+        # Last week: Monday 2025-05-05 to Sunday 2025-05-11
+        # Expenses: Bus Ticket (-15 on 05-05), Project A Software (-10 on 05-11) = 25
+        expected_start = FIXED_TODAY - timedelta(days=FIXED_TODAY.weekday() + 7) # 2025-05-05
+        expected_end = FIXED_TODAY - timedelta(days=FIXED_TODAY.weekday() + 1)   # 2025-05-11
+        response = main.process_query("how much did I spend last week?")
+        self.assertIn("You spent $25.00 last week", response)
+        self.assertIn(f"(from {expected_start.strftime('%Y-%m-%d')} to {expected_end.strftime('%Y-%m-%d')})", response)
+
+    def test_query_spending_in_month_april(self):
+        # Expenses in April 2025: Books (-25 on 04-20), Snacks (-10 on 04-28) = 35
+        # Year is FIXED_TODAY.year = 2025
+        response = main.process_query("what were my expenses in April?")
+        self.assertIn("You spent $35.00 in April 2025", response)
+        self.assertIn("(from 2025-04-01 to 2025-04-30)", response)
+
+    def test_query_spending_in_month_may(self):
+        # Expenses in May 2025: Coffee (-50), Grocery (-20), Restaurant (-30), Bus (-15), Project A Software (-10) = 125
+        response = main.process_query("what were my expenses in may?") # Test lowercase month
+        self.assertIn("You spent $125.00 in May 2025", response)
+        self.assertIn("(from 2025-05-01 to 2025-05-31)", response)
+
+
+    def test_query_income_last_month(self):
+        # FIXED_TODAY is 2025-05-15. Last month is April 2025.
+        # Income in April 2025: Freelance Payment (120.00 on 04-15)
+        response = main.process_query("what was my income last month?")
+        self.assertIn("Your income last month (April 2025) was $120.00", response)
+        self.assertIn("(from 2025-04-01 to 2025-04-30)", response)
+
+    def test_query_total_income(self):
+        # Total income: 200 + 120 + 190 + 50 = 560
+        response = main.process_query("how much income did I receive in total?")
+        self.assertEqual(response, "Your total income is $560.00.")
+        response_variant = main.process_query("total income")
+        self.assertEqual(response_variant, "Your total income is $560.00.")
+
+
+    def test_query_show_income_transactions(self):
+        response = main.process_query("show my income transactions")
+        self.assertIn("Income transactions:", response)
+        self.assertIn("2025-05-10: Project A Bonus ($+50.00, projectA)", response) # Most recent income in mock
+        self.assertIn("2025-05-03: Salary Deposit ($+200.00, salary)", response)
+        self.assertIn("2025-04-15: Freelance Payment ($+120.00, freelance)", response)
+        self.assertIn("2025-03-10: Old Salary Deposit ($+190.00, salary)", response)
+        self.assertNotIn("Coffee Shop", response) # Expense
+
+    def test_query_income_from_category_salary(self):
+        # Income from salary: 200 + 190 = 390
+        response = main.process_query("how much income from salary?")
+        self.assertEqual(response, "You received $390.00 as income from salary.")
+        response_case = main.process_query("income from SALARY") # Test case insensitivity of query
+        self.assertEqual(response_case, "You received $390.00 as income from SALARY.")
+
+
+    def test_query_income_from_category_freelance(self):
+        response = main.process_query("how much income from freelance?")
+        self.assertEqual(response, "You received $120.00 as income from freelance.")
+
+    def test_query_income_from_category_nonexistent(self):
+        response = main.process_query("how much income from unicorn breeding?")
+        self.assertEqual(response, "No income found from unicorn breeding or 'unicorn breeding' is not an income category.")
+
+    def test_query_income_from_category_food(self): # food only has expenses
+        response = main.process_query("how much income from food?")
+        self.assertEqual(response, "No income found from food or 'food' is not an income category.")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces two new major features:

1.  **Spending by Date Range:** You can now query your spending within specific timeframes.
    - Handles queries like "How much did I spend last week?"
    - Handles queries like "What were my expenses in April?" (assumes current year if not specified).
    - A new function `get_spending_by_date_range` was added for this.

2.  **Income Tracking:** You can now track and query your income.
    - Handles queries like "What was my income last month?", "How much income did I receive in total?", "Show my income transactions.", and "How much income from salary?".
    - New functions `get_total_income`, `get_income_by_category`, and `get_income_by_date_range` were added.
    - Transaction display now uses a "+" sign for income amounts.

Comprehensive unit tests have been added for all new functions and query processing logic using mock data and date mocking to ensure reliability.

The README.md file has also been updated to reflect these new capabilities with example usage.